### PR TITLE
fix $command_compare

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,16 +8,17 @@ class swap(
 ) {
 
   $swapfile_path_dirname = dirname($swapfile_path)
+  $free_space_integer    = $threshold_m + $swapfile_size_m
 
   case $::kernel {
     'Linux': {
-      $command_dir = "test -d $swapfile_path_dirname"
-      $command_compare = "test \$((df -mP $swapfile_path_dirname | grep -v Avail | awk '{print \\$4}'))-$threshold_m -gt $swapfile_size_m"
+      $command_dir     = "test -d $swapfile_path_dirname"
+      $command_compare = "test \$(df -mP $swapfile_path_dirname | grep -v Avail | awk '{print \$4}') -gt $free_space_integer"
     }
     default: {
-      $command_dir = 'UNDEF'
-      $command_df_m = 'UNDEF'
-      $command_compare = 'UNDEF'
+      $command_dir     = undef
+      $command_df_m    = undef
+      $command_compare = undef
     }
   }
 


### PR DESCRIPTION
Introduce $free_space_integer to ease needed free space calculation in $command_compare.
Change double parentheses to single parentheses to fix shell error in exec resource.

changed defaults to real ```undef``` instead of the string 'UNDEF'